### PR TITLE
Fixed parsing of comments that end in \r\n, Added missing Date class to compile.js

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -193,7 +193,7 @@
             throw new Error("Name must be present in JSON or options");
         }
         var flow = new Container(name);
-        var defined = comb.merge({Array:Array, String:String, Number:Number, Boolean:Boolean, RegExp:RegExp, Buffer:Buffer}, options.define || {});
+        var defined = comb.merge({Array:Array, String:String, Number:Number, Boolean:Boolean, RegExp:RegExp, Date:Date, Buffer:Buffer}, options.define || {});
         var scope = comb.merge({}, options.scope);
         flowObj.define.forEach(function (d) {
             defined[d.name] = createDefined(d, flow);

--- a/lib/parser/nools/nool.parser.js
+++ b/lib/parser/nools/nool.parser.js
@@ -7,7 +7,7 @@
 
     var parse = function (src, keywords, context) {
         var orig = src;
-        src = src.replace(/\/\/(.*)\n/g, "");
+        src = src.replace(/\/\/(.*)(\r)?\n/g, "");
 
         var blockTypes = new RegExp("^(" + Object.keys(keywords).join("|") + ")"), index;
         while (src && (index = utils.findNextTokenIndex(src)) !== -1) {


### PR DESCRIPTION
While playing with Nools I noticed that the DSL parser fails when comment lines end with \r\n, as the (*.) does not match \r . The quick fix was to add an optional match for the \n. 

Additionally the list of predefined identifiers seemed to be missing the Date type. 
