### PR TITLE
Allow compile to accept an array of file names to load

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -250,7 +250,6 @@ function parse(source) {
     } else {
         ret = compile.parse(source);
     }
-    console.log(ret);
     return ret;
 }
 


### PR DESCRIPTION
nools.compile will now accept an array of file names to be loaded.  each file is read and appended to a buffer and then compiled.  if an array of files is being used, there isnt a sane way to guess what the name should be, so it's required as part of the options object in the case of using an array of files.
