### PR TITLE
Added support to import all rules within a directory

### DIFF
--- a/lib/parser/nools/tokens.js
+++ b/lib/parser/nools/tokens.js
@@ -2,6 +2,7 @@
 
 var utils = require("./util.js"),
     fs = require("fs"),
+	path = require("path"),
     extd = require("../../extended"),
     filter = extd.filter,
     indexOf = extd.indexOf,
@@ -248,21 +249,38 @@ var topLevelTokens = {
             utils.findNextToken(src) === ";" && (src = src.replace(/\s*;/, ""));
             file = file.replace(/[\(|\)]/g, "").split(",");
             if (file.length === 1) {
+	            var files = [];
                 file = utils.resolve(context.file || process.cwd(), file[0].replace(/["|']/g, ""));
-                if (indexOf(context.loaded, file) === -1) {
-                    var origFile = context.file;
-                    context.file = file;
-                    parse(fs.readFileSync(file, "utf8"), topLevelTokens, context);
-                    context.loaded.push(file);
-                    context.file = origFile;
-                }
+	            var stats = fs.statSync(file);
+	            if(stats.isFile()) {
+		            files.push(file);
+	            } else if(stats.isDirectory()) {
+		            files = fs.readdirSync(file);
+	            }
+
+	            if(files.length) {
+					for(var rule in files) {
+						var rule_path = path.join(file, files[rule]);
+						if (indexOf(context.loaded, rule_path) === -1) {
+							var origFile = context.file;
+							context.file = rule_path;
+							parse(fs.readFileSync(rule_path, "utf8"), topLevelTokens, context);
+							context.loaded.push(rule_path);
+							context.file = origFile;
+						}
+					}
+	            } else {
+		            throw new Error("error reading file or directory: " + err);
+	            }
+
                 return src;
             } else {
-                throw new Error("import accepts a single file");
+                throw new Error("import accepts a single file or directory");
             }
         } else {
             throw new Error("unexpected token : expected : '(' found : '" + utils.findNextToken(src) + "'");
         }
+
 
     },
 


### PR DESCRIPTION
I added support to specify a directory instead of a file using the import tag in the DSL file. All rules in this directory are added to the current flow.
